### PR TITLE
Add create-ticket prompt for generating well-structured GitHub issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,23 @@ Lists repositories for a specified organization.
 - Detailed repository data including URLs, topics, and metadata
 - Pagination information for multiple pages
 
+## Available Prompts
+
+### 1. `create-ticket`
+Generates a well-structured GitHub issue for features, bugs, or tasks using a specialized IssueBot prompt.
+
+**Parameters:**
+- `rough_details` (string, optional): Optional rough details for the issue to be created
+
+**Returns:** A formatted prompt that guides the AI to:
+- Ask clarifying questions if essential details are missing
+- Generate a GitHub issue in pure Markdown with:
+  - Title (imperative, ≤ 60 characters)
+  - Tag (Feature, Bug, or Task)
+  - Brief introduction (1-2 sentences)
+  - Detailed description
+  - Requirements as checklist items
+
 ## Environment Variables
 
 ### GitHub Authentication

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 	listGithubRepositoriesSchema,
 	listGithubRepositoriesHandler,
 } from "./tools/index.js";
+import { createTicketPromptSchema, createTicketPromptHandler } from "./prompts/index.js";
 
 // Define our MCP agent with tools
 export class MyMCP extends McpAgent {
@@ -77,6 +78,16 @@ export class MyMCP extends McpAgent {
 			async (params, extra) => {
 				const env = (this as any).env as Env;
 				return listGithubRepositoriesHandler(params, { server: this.server, env });
+			},
+		);
+
+		// Create ticket prompt
+		this.server.prompt(
+			"create-ticket",
+			"Generate a well-structured GitHub issue for features, bugs, or tasks",
+			createTicketPromptSchema.shape,
+			async (params) => {
+				return createTicketPromptHandler(params);
 			},
 		);
 	}

--- a/src/prompts/create-ticket.ts
+++ b/src/prompts/create-ticket.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import type { GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
+
+// The prompt template content
+const PROMPT_TEMPLATE = `You are **IssueBot**, a specialist at drafting crystal-clear GitHub issues for features, bugs, or tasks.
+
+## Your operating rules
+
+1. **Clarify first**  
+   If any essential detail is missing, respond only with concise clarifying questions. Do not start writing the issue until you have everything you need.
+
+2. **When ready, output a GitHub issue in pure Markdown — nothing more, nothing less — using exactly this skeleton:**
+
+<Title line>  
+**Tag:** \`Feature\` | \`Bug\` | \`Task\`  
+<One-to-two-sentence introduction — no heading>
+
+## Description
+
+<Full, developer-ready explanation of the feature, bug, or task. For bugs: current vs. expected behaviour; for features: user story or rationale; for tasks: clear scope and purpose.>
+
+## Requirements
+
+- [ ] <Each acceptance criterion or fix condition as a checklist item, written in the past tense and testable>
+- [ ] <Add as many checklist items as needed>
+
+### Formatting constraints
+
+- Title: imperative, ≤ 60 characters, no ending punctuation.
+- Tag: exactly one of \`Feature\`, \`Bug\`, or \`Task\` based on the nature of the issue.
+- Introduction: no heading, maximum two sentences.
+- Use \`- [ ]\` for every requirement.
+- **Do not** add any extra sections, headings, commentary, code fences, or pre/post-amble text.
+- When producing the issue, return _only_ the raw Markdown shown above.
+
+3. **Interaction etiquette**
+   - After asking clarifying questions, wait for the user's answers.
+   - Once all answers are provided, output the final issue instantly and end your message.
+
+# (No additional content beyond this line is ever included in your replies)
+
+**INSERT ROUGH DETAILS FOR ISSUE**`;
+
+// Schema for create-ticket prompt arguments
+export const createTicketPromptSchema = z.object({
+	rough_details: z
+		.string()
+		.optional()
+		.describe("Optional rough details for the issue to be created"),
+});
+
+// Handler for the create-ticket prompt
+export async function createTicketPromptHandler(
+	params: z.infer<typeof createTicketPromptSchema>,
+): Promise<GetPromptResult> {
+	// Replace the placeholder with the provided rough details
+	let finalPrompt = PROMPT_TEMPLATE;
+	if (params.rough_details) {
+		finalPrompt = PROMPT_TEMPLATE.replace(
+			"**INSERT ROUGH DETAILS FOR ISSUE**",
+			params.rough_details,
+		);
+	}
+
+	return {
+		messages: [
+			{
+				role: "user",
+				content: {
+					type: "text",
+					text: finalPrompt,
+				},
+			},
+		],
+	};
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,0 +1,1 @@
+export { createTicketPromptSchema, createTicketPromptHandler } from "./create-ticket.js";


### PR DESCRIPTION
## Summary
- Introduces prompt support to the MCP server, extending it beyond just tools
- Adds a `create-ticket` prompt that generates well-formatted GitHub issues for features, bugs, or tasks
- Updates documentation to reflect the new prompt capability

## Test plan
- [ ] Start the MCP server locally with `npm run dev`
- [ ] Connect an MCP client to the `/sse` endpoint
- [ ] Test the `create-ticket` prompt with various rough details
- [ ] Verify the prompt generates properly formatted GitHub issues following the IssueBot template
- [ ] Confirm the prompt handles both with and without rough_details parameter

🤖 Generated with [Claude Code](https://claude.ai/code)